### PR TITLE
Fix relative path error

### DIFF
--- a/historical-bank.gemspec
+++ b/historical-bank.gemspec
@@ -26,11 +26,9 @@ Gem::Specification.new do |s|
   s.homepage    = 'https://github.com/Skyscanner/historical-bank-ruby'
   s.license     = 'Apache-2.0'
 
-  require 'rake'
-  s.files = FileList['lib/**/*.rb', 'Gemfile', 'examples/*.rb',
-                     'historical-bank.gemspec', 'spec/**/*.rb'].to_a
-  s.files += ['README.md', 'LICENSE', 'CONTRIBUTING.md', 'AUTHORS',
-              'CHANGELOG.md', 'spec/fixtures/time-series-2015-09.json']
+  s.files = Dir['lib/**/*.rb', 'examples/*.rb', 'spec/**/*.rb', 'spec/**/*.json'].to_a
+  s.files += ['Gemfile', 'historical-bank.gemspec', 'README.md', 'LICENSE',
+    'CONTRIBUTING.md', 'AUTHORS', 'CHANGELOG.md']
 
   s.test_files = s.files.grep(%r{^spec/})
 


### PR DESCRIPTION
Fixes the error "Does it try to require a relative path? That's been removed in Ruby 1.9. Bundler cannot continue."